### PR TITLE
Fix

### DIFF
--- a/d365fo.tools/d365fo.tools.psd1
+++ b/d365fo.tools/d365fo.tools.psd1
@@ -130,6 +130,7 @@
 						'Invoke-D365TableBrowser',
 
 						'New-D365Bacpac',
+						'New-D365CAReport',
 						'New-D365ISVLicense',
 						'New-D365TopologyFile',
 						

--- a/d365fo.tools/functions/new-d365careport.ps1
+++ b/d365fo.tools/functions/new-d365careport.ps1
@@ -23,7 +23,7 @@
         Name of the Module to analyse
         
     .PARAMETER Model
-        Name of the Model to analyse        
+        Name of the Model to analyse
         
     .EXAMPLE
         PS C:\> New-D365CAReport -Path "c:\temp\CAReport.xlsx" -module "ApplicationSuite" -model "MyOverLayerModel"
@@ -37,9 +37,9 @@
 function New-D365CAReport {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $True, Position = 1 )]
+        [Parameter(Mandatory = $false, Position = 1 )]
         [Alias('File')]
-        [string] $Path,
+        [string] $Path = (Join-Path $Script:DefaultTempPath "CAReport.xlsx"),
 
         [Parameter(Mandatory = $false, Position = 2 )]
         [string] $BinDir = "$Script:PackageDirectory\bin",
@@ -55,7 +55,7 @@ function New-D365CAReport {
         [string] $Model,
 
         [Parameter(Mandatory = $false, Position = 6 )]
-        [string] $XmlLog = "C:\temp\BPCheckLogcd.xml"
+        [string] $XmlLog = (Join-Path $Script:DefaultTempPath "BPCheckLogcd.xml")
 
 
     )


### PR DESCRIPTION
1. I know that you know about putting the function name into the psd1 file.

2. When you want to load the module from your local repository, you need to make sure that you are 1 level deeper than earlier. See picture.

![image](https://user-images.githubusercontent.com/8750181/47580063-29659600-d94e-11e8-975e-17c68ed8f5bd.png)

So for me to load the module from my local repo, i have to execute the following command

```
Import-Module C:\GIT\GITHUB\d365fo.tools.Workspace\d365fo.tools\d365fo.tools -Force -PassThru
```

![image](https://user-images.githubusercontent.com/8750181/47580337-f7086880-d94e-11e8-8296-6c6ad2e1714d.png)


The reason for that is we had to restructure the ENTIRE folder structure to fit into the new dependencies we have for the tools that we use to run the pester tests and validation when we the PR validation.

I believe that the issue you faced today was that you were loading a level to high, so the module didn't load correctly - if not, let me know, so we can look into your development setup.

![image](https://user-images.githubusercontent.com/8750181/47580309-e48e2f00-d94e-11e8-9dd6-8a94f5e83ce3.png)
